### PR TITLE
Bump Jetpack WindowManager to 1.0.0 stable

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/butterfly/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/butterfly/Dependencies.kt
@@ -11,7 +11,7 @@ object Versions {
     internal const val KOTLIN_COROUTINE = "1.5.2"
 
     internal const val MATERIAL = "1.4.0"
-    internal const val ANDROIDX_WINDOW = "1.0.0-rc01"
+    internal const val ANDROIDX_WINDOW = "1.0.0"
     internal const val ANDROIDX_APPCOMPAT = "1.4.0"
     internal const val ANDROIDX_CORE = "1.7.0"
     internal const val ANDROIDX_LIFECYCLE = "2.4.0"


### PR DESCRIPTION
### 🎯 Goal
Bump Jetpack WindowManager to [1.0.0](https://developer.android.com/jetpack/androidx/releases/window#1.0.0) stable.